### PR TITLE
Adding Luuuuu for highlighting on leaderboards.

### DIFF
--- a/react/src/components/Helpers.js
+++ b/react/src/components/Helpers.js
@@ -70,6 +70,7 @@ export const divisionMapping = {
   'Price-Murray': 'D2',
   'Jones-Allen': 'D2',
   'Freddie-Hutton': 'D2',
+  Luuuuu: 'D2',
   Howe: 'D3',
   Lemieux: 'D3',
   Dionne: 'D3',


### PR DESCRIPTION
## What?
Added Luuuuu to the list of leagues and the division for the helper function.

## Why?
Highlighting does not work for Luuuuu teams on the leaderboard. Fixes #121.

## How?
I just added Luuuuu to the helpers.js file. One line fix. Pretty straightforward.

## Testing?
Did it manually for now in the browser. If we're doing some codegen stuff on that, it's probably worth adding testing in at that point, but for now, this is an easy one.

## Screenshots

![highlight-effect](https://user-images.githubusercontent.com/438676/137611844-be2d1ef6-8475-4d3d-93f0-0d977b6ce4f2.gif)

## Anything Else?

Nope!