### PR TITLE
Bugfixes - Trophy Room Font FOUC and hypenated word breaks

### DIFF
--- a/react/legacy/public/index.html
+++ b/react/legacy/public/index.html
@@ -25,8 +25,23 @@
       Learn how to configure a non-root public URL by running `npm run build`.
     -->
     <title>Old Time Hockey!</title>
+    <link rel="preload" href="https://fonts.googleapis.com/css2?family=Anton&display=swap&text=ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789&display=swap" as="style" />
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css" />
-    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Anton&display=swap" />
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Anton&display=swap&text=ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789&display=swap" />
+    <style>
+      /* Font fallback to prevent FOUC */
+      .font-fallback {
+        font-family: Arial, sans-serif;
+      }
+      @font-face {
+        font-family: 'Anton';
+        font-style: normal;
+        font-weight: 400;
+        font-display: swap;
+        src: local('Anton Regular'), local('Anton-Regular'), url(https://fonts.gstatic.com/s/anton/v11/1Ptgg87LROyAm3K9-C8CSKlvPfE.woff2) format('woff2');
+        unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
+      }
+    </style>
   </head>
   <body>
     <noscript>You need to enable JavaScript to run this app.</noscript>

--- a/react/legacy/src/components/TrophyBanner.js
+++ b/react/legacy/src/components/TrophyBanner.js
@@ -78,7 +78,7 @@ const TrophyBanner = ({
           </React.Fragment>
         ))}
         <span className={styles.accordionIcon}>
-          <i className={isExpanded ? 'fas fa-chevron-up' : 'fas fa-chevron-down'}></i>
+          <i className="fas fa-chevron-down"></i>
         </span>
       </div>
       

--- a/react/legacy/src/components/TrophyBanner.js
+++ b/react/legacy/src/components/TrophyBanner.js
@@ -68,7 +68,7 @@ const TrophyBanner = ({
       data-banner-id={id}
     >
       <div 
-        className={styles.title}
+        className={`${styles.title} font-fallback`}
         onClick={handleTitleClick}
       >
         {title.split(/<br\s*\/?>/).map((part, index, array) => (
@@ -124,7 +124,7 @@ const TrophyBanner = ({
                 return (
                   <li 
                     key={index}
-                    className={`${styles.listItem} ${isHighlighted ? styles.highlighted : ''}`}
+                    className={`${styles.listItem} ${isHighlighted ? styles.highlighted : ''} font-fallback`}
                   >
                     {year} - {' '}
                     <span 

--- a/react/legacy/src/components/TrophyBannerInitializer.js
+++ b/react/legacy/src/components/TrophyBannerInitializer.js
@@ -1,4 +1,4 @@
-import { useEffect, useContext, createContext, useState, useCallback } from 'react';
+import { useEffect, useContext, createContext, useState, useCallback, useRef } from 'react';
 export const BannerContext = createContext();
 export const useBannerContext = () => useContext(BannerContext);
 export const BannerProvider = ({ children }) => {
@@ -55,6 +55,33 @@ export const BannerProvider = ({ children }) => {
 
 const TrophyBannerInitializer = () => {
   const { toggleBanner } = useBannerContext();
+  const fontLoadedRef = useRef(false);
+  
+  useEffect(() => {
+    if (fontLoadedRef.current) return;
+    
+    // Use the Font Loading API to detect when Anton is loaded
+    if ('fonts' in document) {
+      document.fonts.ready.then(() => {
+        document.fonts.forEach(font => {
+          if (font.family.toLowerCase() === 'anton' && font.status === 'loaded') {
+            fontLoadedRef.current = true;
+            // Remove the font-fallback class from all elements
+            document.querySelectorAll('.font-fallback').forEach(el => {
+              el.classList.remove('font-fallback');
+            });
+          }
+        });
+      });
+    } else {
+      // Fallback for browsers that don't support Font Loading API
+      setTimeout(() => {
+        document.querySelectorAll('.font-fallback').forEach(el => {
+          el.classList.remove('font-fallback');
+        });
+      }, 1000); 
+    }
+  }, []);
   
   useEffect(() => {
     const updateBanners = () => {

--- a/react/legacy/src/styles/TrophyBanner.module.css
+++ b/react/legacy/src/styles/TrophyBanner.module.css
@@ -8,7 +8,7 @@
   box-shadow: 0 8px 16px 4px rgba(0, 0, 0, 0.4);
   padding-bottom: 15px;
   width: var(--banner-width, 285px);
-  transition: min-height 0.3s ease;
+  transition: min-height 0.35s cubic-bezier(0.4, 0, 0.2, 1), padding-bottom 0.35s cubic-bezier(0.4, 0, 0.2, 1);
   border-top: 2px solid white;
 }
 
@@ -23,7 +23,7 @@
 }
 
 .bannerContent {
-  transition: max-height 0.3s ease, opacity 0.3s ease;
+  transition: max-height 0.35s cubic-bezier(0.4, 0, 0.6, 1), opacity 0.35s cubic-bezier(0.4, 0, 0.6, 1);
   max-height: 1000px;
   opacity: 1;
   overflow: hidden;
@@ -70,7 +70,7 @@
   transform: translateY(-50%);
   font-size: 1.2rem;
   opacity: 0;
-  transition: opacity 0.3s ease;
+  transition: opacity 0.35s cubic-bezier(0.4, 0, 0.2, 1), transform 0.35s cubic-bezier(0.4, 0, 0.2, 1);
 }
 
 .accordionIcon i {
@@ -149,15 +149,15 @@
     white-space: normal;
     overflow-wrap: break-word;
     word-wrap: break-word;
+    word-break: keep-all;
     line-height: 1.2;
     font-size: calc(var(--title-font-size, 2.25rem) * 0.9);
     min-height: 80px;
     display: flex;
     flex-direction: column;
     justify-content: center;
-    max-width: 80%;
+    max-width: 85%;
     margin: 0 auto;
-    hyphens: auto;
     word-spacing: 0.1em;
   }
   
@@ -172,26 +172,34 @@
 */
 @media (max-width: 768px) {
   .banner.expanded {
-    min-height: 200px !important;
-    padding-bottom: 15px !important;
+    min-height: 200px;
+    padding-bottom: 15px;
   }
   
   .banner.expanded .title {
-    padding: 20px 5px 5px 5px !important;
+    padding: 20px 5px 5px 5px;
   }
   
   .banner.expanded .bannerContent {
-    max-height: 1000px !important;
-    opacity: 1 !important;
+    max-height: 1000px;
+    opacity: 1;
+  }
+  
+  .banner.expanded .accordionIcon i {
+    transform: rotate(180deg);
   }
   
   .banner.collapsed {
-    min-height: auto !important;
-    padding-bottom: 0 !important;
+    min-height: auto;
+    padding-bottom: 0;
   }
   
   .banner.collapsed .bannerContent {
-    max-height: 0 !important;
-    opacity: 0 !important;
+    max-height: 0;
+    opacity: 0;
+  }
+  
+  .banner.collapsed .accordionIcon i {
+    transform: rotate(0deg);
   }
 }


### PR DESCRIPTION
Fixing the hyphen word breaks is a simple matter, but handling font FOUC (Flash of Un-styled Content) is more challenging. To address it, I preload the font so it doesn’t block rendering, declare it globally in the header via an @font-face rule, and implement a comprehensive strategy using `font-display: swap` including fallbacks for older browsers that may not support the Fonts API. This ensures that when the trophy room loads, the Anton font is already in place and there’s no FOUC.